### PR TITLE
Ui translations

### DIFF
--- a/config/language/es/block.block.drupalcampblockforlandingaboutsponsoring.yml
+++ b/config/language/es/block.block.drupalcampblockforlandingaboutsponsoring.yml
@@ -1,3 +1,4 @@
 settings:
   title: 'Conviértete en patrocinador'
   body: '<p>Patrocina el evento y obtén a cambio difusión de tu marca.</p>'
+  download_text: 'Descarga el PDF'

--- a/config/language/es/block.block.drupalcampblockforlandingaboutthecommunity.yml
+++ b/config/language/es/block.block.drupalcampblockforlandingaboutthecommunity.yml
@@ -1,3 +1,4 @@
 settings:
   title: 'Únete a la AED'
   body: '<p>La Asociación Española de Drupal crece cada año. Empresas, autónomos, y estudiantes forman una de las familias más influyentes del desarrollo web nacional.</p>'
+  link_text: 'Únete a la asociación'

--- a/config/system.action.user_add_role_action.editor.yml
+++ b/config/system.action.user_add_role_action.editor.yml
@@ -1,0 +1,14 @@
+uuid: 54b19e7f-bdc2-4e72-a383-9037235f1c40
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.editor
+  module:
+    - user
+id: user_add_role_action.editor
+label: 'Add the Editor role to the selected users'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: editor

--- a/config/system.action.user_remove_role_action.editor.yml
+++ b/config/system.action.user_remove_role_action.editor.yml
@@ -1,0 +1,14 @@
+uuid: f16bff62-6906-4d22-8c6c-f3b53897b2bf
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.editor
+  module:
+    - user
+id: user_remove_role_action.editor
+label: 'Remove the Editor role from the selected users'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: editor

--- a/config/user.role.administrator.yml
+++ b/config/user.role.administrator.yml
@@ -6,6 +6,6 @@ _core:
   default_config_hash: Om6FEO7vZZMkPIbVvfxtdkWerQ2PvQM4sWUd6Q3ZnfI
 id: administrator
 label: Administrator
-weight: 2
+weight: -7
 is_admin: true
 permissions: {  }

--- a/config/user.role.anonymous.yml
+++ b/config/user.role.anonymous.yml
@@ -6,7 +6,7 @@ _core:
   default_config_hash: j5zLMOdJBqC0bMvSdth5UebkprJB8g_2FXHqhfpJzow
 id: anonymous
 label: 'Anonymous user'
-weight: 0
+weight: -10
 is_admin: false
 permissions:
   - 'access content'

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -6,7 +6,7 @@ _core:
   default_config_hash: dJ0L2DNSj5q6XVZAGsuVDpJTh5UeYkIPwKrUOOpr8YI
 id: authenticated
 label: 'Authenticated user'
-weight: 1
+weight: -9
 is_admin: false
 permissions:
   - 'access content'

--- a/config/user.role.editor.yml
+++ b/config/user.role.editor.yml
@@ -1,0 +1,13 @@
+uuid: b594dacb-42fa-4525-9362-51f22629fd2a
+langcode: en
+status: true
+dependencies: {  }
+id: editor
+label: Editor
+weight: -8
+is_admin: null
+permissions:
+  - 'translate interface'
+  - 'access administration pages'
+  - 'view the administration theme'
+  - 'access toolbar'

--- a/web/modules/custom/dcamp/dcamp.module
+++ b/web/modules/custom/dcamp/dcamp.module
@@ -21,3 +21,22 @@ function dcamp_theme($existing, $type, $theme, $path){
    ),
  ];
 }
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Make the mailchimp submit button translatable.
+ *
+ * This should be fixed on Mailchimp level.
+ *
+ * @todo Submit a patch to the Mailchimp module.
+ *
+ * @param $form
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
+ * @param $form_id
+ */
+function dcamp_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  if("mailchimp_signup_subscribe_block_dcamp_mailchimp_form" == $form_id){
+    $form['submit']['#value'] = t('Submit');
+  }
+}


### PR DESCRIPTION
Config Entity translations can go in to the config folder, but interface translations are not included in config. 

The only way to 'import' interface translation is through a .po file using the Drupal UI. As far as I know there is no drush / drupal console command in core that can do this, so no way to add it to ansistrano tasks easily.

I have translated everything on local, but since I have no access to the production website, I cannot import my local .po file there. I've created an account, so if someone can give me this new 'editor' permission, then I can upload the strings.

This PR translates a couple of missing config entity strings, and adds a new 'Editor' role to which we can concede different permissions as we continue. Currently the only permission it has is is to 'translate interface'. Later on we can give it permissions to edit/create content.

This PR also translates the submit button on the mailchimp form that currently seems to be hardcoded.
