### PR TITLE
[COLDFIX] Don't render a signup form if there are no lists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
     },
     "patches": {
       "drupal/mailchimp": {
-        "Allow translating signup forms": "https://www.drupal.org/files/issues/translation_for_email-2821153-3.patch"
+        "Allow translating signup forms": "https://www.drupal.org/files/issues/translation_for_email-2821153-3.patch",
+        "Don't show a signup form if there aren't lists": "https://www.drupal.org/files/issues/don_t_render_a_signup-2822659-2.patch"
       }
     }
   }


### PR DESCRIPTION
Further details at https://www.drupal.org/node/2822659.

This patch fixes warnings when you set up a local development environment without a Mailchimp list.