### PR TITLE
Fix URI config elements

### DIFF
--- a/config/language/es/block.block.drupalcampblockforlandingaboutsponsoring.yml
+++ b/config/language/es/block.block.drupalcampblockforlandingaboutsponsoring.yml
@@ -2,3 +2,4 @@ settings:
   title: 'Conviértete en patrocinador'
   body: '<p>Patrocina el evento y obtén a cambio difusión de tu marca.</p>'
   download_text: 'Descarga el dossier'
+  download_url: 'https://drive.google.com/open?id=0B5Zv1LP5pgikZVd1SktNWHZaTEE'

--- a/web/modules/custom/dcamp/config/schema/dcamp.schema.yml
+++ b/web/modules/custom/dcamp/config/schema/dcamp.schema.yml
@@ -43,7 +43,7 @@ block.settings.dcamp_landing_about_community_block:
       type: text
       label: 'Link text'
     link_url:
-      type: url
+      type: uri
       label: 'Link URL'
 
 block.settings.dcamp_landing_about_location_block:
@@ -71,7 +71,7 @@ block.settings.dcamp_landing_about_sponsor_block:
       type: text
       label: 'Download text'
     download_url:
-      type: url
+      type: text
       label: 'Download URL'
 
 block.settings.dcamp_landing_stay_updated_block:


### PR DESCRIPTION
There was a typo in a config type (it's uri, not URL).

I also made the sponsor prospect of text type because uri
config elements can't be translated.