### PR TITLE
62sponsors

### DIFF
--- a/config/core.base_field_override.node.sponsor.promote.yml
+++ b/config/core.base_field_override.node.sponsor.promote.yml
@@ -1,0 +1,22 @@
+uuid: a8b0a14c-6b27-4927-bc3c-955a35730e12
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+id: node.sponsor.promote
+field_name: promote
+entity_type: node
+bundle: sponsor
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.node.sponsor.title.yml
+++ b/config/core.base_field_override.node.sponsor.title.yml
@@ -1,0 +1,18 @@
+uuid: 3c4cecb9-ff95-4f10-9096-0ae80dc24fb8
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+id: node.sponsor.title
+field_name: title
+entity_type: node
+bundle: sponsor
+label: Name
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.entity_form_display.node.sponsor.default.yml
+++ b/config/core.entity_form_display.node.sponsor.default.yml
@@ -1,0 +1,81 @@
+uuid: 03ece32e-26d2-4278-b921-88a7722e0176
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.sponsor.field_logo
+    - field.field.node.sponsor.field_sponsor_type
+    - field.field.node.sponsor.field_url
+    - image.style.thumbnail
+    - node.type.sponsor
+  module:
+    - image
+    - link
+    - path
+id: node.sponsor.default
+targetEntityType: node
+bundle: sponsor
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  field_logo:
+    weight: 32
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+  field_sponsor_type:
+    weight: 33
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+  field_url:
+    weight: 31
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+  langcode:
+    type: language_select
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/core.entity_view_display.node.sponsor.default.yml
+++ b/config/core.entity_view_display.node.sponsor.default.yml
@@ -1,0 +1,48 @@
+uuid: a57ef3fb-02ab-4fb1-8c5a-2a004dbd1e3a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.sponsor.field_logo
+    - field.field.node.sponsor.field_sponsor_type
+    - field.field.node.sponsor.field_url
+    - image.style.sponsor_logo
+    - node.type.sponsor
+  module:
+    - image
+    - link
+    - options
+    - user
+id: node.sponsor.default
+targetEntityType: node
+bundle: sponsor
+mode: default
+content:
+  field_logo:
+    weight: 1
+    label: hidden
+    settings:
+      image_style: sponsor_logo
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+  field_sponsor_type:
+    weight: 2
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+  field_url:
+    weight: 0
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
+hidden:
+  langcode: true
+  links: true

--- a/config/core.entity_view_display.node.sponsor.teaser.yml
+++ b/config/core.entity_view_display.node.sponsor.teaser.yml
@@ -1,0 +1,18 @@
+uuid: 0a2b8025-6164-4a34-a564-14b91ca066dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.sponsor
+  module:
+    - user
+id: node.sponsor.teaser
+targetEntityType: node
+bundle: sponsor
+mode: teaser
+content:
+  links:
+    weight: 100
+hidden:
+  langcode: true

--- a/config/field.field.node.sponsor.field_logo.yml
+++ b/config/field.field.node.sponsor.field_logo.yml
@@ -1,0 +1,38 @@
+uuid: 5bc34687-a322-47a7-96fe-7d756f1744d1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_logo
+    - node.type.sponsor
+  module:
+    - image
+id: node.sponsor.field_logo
+field_name: field_logo
+entity_type: node
+bundle: sponsor
+label: Logo
+description: 'Sponsor logo'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: true
+  title_field_required: true
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/config/field.field.node.sponsor.field_sponsor_type.yml
+++ b/config/field.field.node.sponsor.field_sponsor_type.yml
@@ -1,0 +1,21 @@
+uuid: e5662247-784c-4bc3-bdff-d8ab022919db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sponsor_type
+    - node.type.sponsor
+  module:
+    - options
+id: node.sponsor.field_sponsor_type
+field_name: field_sponsor_type
+entity_type: node
+bundle: sponsor
+label: 'Sponsor type'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/field.field.node.sponsor.field_url.yml
+++ b/config/field.field.node.sponsor.field_url.yml
@@ -1,0 +1,23 @@
+uuid: 23a80989-b9cf-47ce-aecc-35cc5bfaf2b3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_url
+    - node.type.sponsor
+  module:
+    - link
+id: node.sponsor.field_url
+field_name: field_url
+entity_type: node
+bundle: sponsor
+label: URL
+description: 'Sponsor url to link in the block'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+field_type: link

--- a/config/field.storage.node.field_logo.yml
+++ b/config/field.storage.node.field_logo.yml
@@ -1,0 +1,30 @@
+uuid: e49673e7-d22b-4047-9d93-0eae68d05ba6
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_logo
+field_name: field_logo
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: 'Sponsor logo'
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_sponsor_type.yml
+++ b/config/field.storage.node.field_sponsor_type.yml
@@ -1,0 +1,33 @@
+uuid: d0b924c9-40bf-452b-aabd-84d2f82642ca
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_sponsor_type
+field_name: field_sponsor_type
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: silver
+      label: Silver
+    -
+      value: gold
+      label: Gold
+    -
+      value: platinium
+      label: Platinium
+    -
+      value: diamond
+      label: Diamond
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/field.storage.node.field_url.yml
+++ b/config/field.storage.node.field_url.yml
@@ -1,0 +1,19 @@
+uuid: 3e9968c9-7936-40cc-b438-c5714bb3a33b
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_url
+field_name: field_url
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/image.style.sponsor_logo.yml
+++ b/config/image.style.sponsor_logo.yml
@@ -1,0 +1,15 @@
+uuid: 92ba21f1-102d-42b3-8087-eb12608ac4ba
+langcode: en
+status: true
+dependencies: {  }
+name: sponsor_logo
+label: 'Sponsor logo (Heigth: 75)'
+effects:
+  d12b1ce6-9c5d-4d58-87c8-6da1be8294a6:
+    uuid: d12b1ce6-9c5d-4d58-87c8-6da1be8294a6
+    id: image_scale
+    weight: 1
+    data:
+      width: null
+      height: 75
+      upscale: false

--- a/config/language.content_settings.node.sponsor.yml
+++ b/config/language.content_settings.node.sponsor.yml
@@ -1,0 +1,11 @@
+uuid: c2ece097-882a-446e-94fa-20bdd3ae1f9a
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+id: node.sponsor
+target_entity_type_id: node
+target_bundle: sponsor
+default_langcode: site_default
+language_alterable: false

--- a/config/node.type.sponsor.yml
+++ b/config/node.type.sponsor.yml
@@ -1,0 +1,17 @@
+uuid: 673488af-a23f-449c-81c7-e7dbb0540339
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Sponsor
+type: sponsor
+description: 'Drupalcamp sponsor'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false

--- a/config/views.view.sponsors.yml
+++ b/config/views.view.sponsors.yml
@@ -1,0 +1,459 @@
+uuid: 5d8660ac-6402-4e46-bddd-28cbb4418d75
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_logo
+    - field.storage.node.field_url
+    - image.style.sponsor_logo
+    - node.type.sponsor
+  module:
+    - image
+    - link
+    - node
+    - options
+    - user
+id: sponsors
+label: Sponsors
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 20
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_url:
+          id: field_url
+          table: node__field_url
+          field: field_url
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: true
+            url_plain: true
+            rel: nofollow
+            target: _blank
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_logo:
+          id: field_logo
+          table: node__field_logo
+          field: field_logo
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a href="{{ field_url }} " title="Open the {{ title }} webpage">{{ field_logo }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: sponsor_logo
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sponsor: sponsor
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_sponsor_type_value:
+          id: field_sponsor_type_value
+          table: node__field_sponsor_type
+          field: field_sponsor_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            silver: silver
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: 'Silver sponsors'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_logo'
+        - 'config:field.storage.node.field_url'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: 'silver sponsor'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_logo'
+        - 'config:field.storage.node.field_url'
+  block_2:
+    display_plugin: block
+    id: block_2
+    display_title: 'gold sponsor'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      title: 'Gold sponsors'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sponsor: sponsor
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_sponsor_type_value:
+          id: field_sponsor_type_value
+          table: node__field_sponsor_type
+          field: field_sponsor_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            gold: gold
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_logo'
+        - 'config:field.storage.node.field_url'


### PR DESCRIPTION
https://github.com/AsociacionDrupalES/DrupalCampSpain/issues/62

- Sponsor content type created with:
  - Title
  - Url
  - Image
  - Sponsor type

- Image style to render the sponsor created. 
- Block view listing sponsors created with 2 display, one with a silver filter and one with a gold filter.

Issue is not finished yet, we have to theme it but maybe we can do it in the homepage issue or when it be done.
