### PR TITLE
#84: Added collaborators sponsor type.

### DIFF
--- a/config/field.storage.node.field_sponsor_type.yml
+++ b/config/field.storage.node.field_sponsor_type.yml
@@ -23,6 +23,9 @@ settings:
     -
       value: silver
       label: Silver
+    -
+      value: collaborators
+      label: Collaborators
   allowed_values_function: ''
 module: options
 locked: false

--- a/config/views.view.sponsors.yml
+++ b/config/views.view.sponsors.yml
@@ -687,6 +687,93 @@ display:
         - 'config:field.storage.node.field_logo'
         - 'config:field.storage.node.field_sponsor_type'
         - 'config:field.storage.node.field_url'
+  collaborators:
+    display_plugin: block
+    id: collaborators
+    display_title: collaborators
+    position: 3
+    display_options:
+      display_extenders: {  }
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sponsor: sponsor
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_sponsor_type_value:
+          id: field_sponsor_type_value
+          table: node__field_sponsor_type
+          field: field_sponsor_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            collaborators: collaborators
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
+      defaults:
+        filters: false
+        filter_groups: false
+        title: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      display_description: ''
+      title: Collaborators
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_logo'
+        - 'config:field.storage.node.field_url'
   diamond:
     display_plugin: block
     id: diamond


### PR DESCRIPTION
#84 I added collaborators as new sponsor type. I added a new block display in the sponsor view that only list the collaborators elements (I'm not sure if it is a required block but maybe can be useful).