### PR TITLE
Translate articles and blocks

### DIFF
--- a/config/core.base_field_override.comment.comment.changed.yml
+++ b/config/core.base_field_override.comment.comment.changed.yml
@@ -1,0 +1,18 @@
+uuid: 872d92bf-009b-4b30-974a-6feedeb09f12
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.changed
+field_name: changed
+entity_type: comment
+bundle: comment
+label: Changed
+description: 'The time that the comment was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/core.base_field_override.comment.comment.created.yml
+++ b/config/core.base_field_override.comment.comment.created.yml
@@ -1,0 +1,18 @@
+uuid: b784ec47-5009-46f5-aec6-a0b5423cc51d
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.created
+field_name: created
+entity_type: comment
+bundle: comment
+label: Created
+description: 'The time that the comment was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/core.base_field_override.comment.comment.homepage.yml
+++ b/config/core.base_field_override.comment.comment.homepage.yml
@@ -1,0 +1,18 @@
+uuid: 7c46a613-4349-4629-aef6-36c5858542b6
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.homepage
+field_name: homepage
+entity_type: comment
+bundle: comment
+label: Homepage
+description: 'The comment author''s home page address.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: uri

--- a/config/core.base_field_override.comment.comment.hostname.yml
+++ b/config/core.base_field_override.comment.comment.hostname.yml
@@ -1,0 +1,18 @@
+uuid: 33832600-5cfa-496d-b765-186c3fd957dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.hostname
+field_name: hostname
+entity_type: comment
+bundle: comment
+label: Hostname
+description: 'The comment author''s hostname.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.base_field_override.comment.comment.mail.yml
+++ b/config/core.base_field_override.comment.comment.mail.yml
@@ -1,0 +1,18 @@
+uuid: e3fef0c5-504e-46b3-a4aa-9e216e93454c
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.mail
+field_name: mail
+entity_type: comment
+bundle: comment
+label: Email
+description: 'The comment author''s email address.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/core.base_field_override.comment.comment.name.yml
+++ b/config/core.base_field_override.comment.comment.name.yml
@@ -1,0 +1,20 @@
+uuid: f7243d28-0609-47f4-9646-13c047254658
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.name
+field_name: name
+entity_type: comment
+bundle: comment
+label: Name
+description: 'The comment author''s name.'
+required: false
+translatable: false
+default_value:
+  -
+    value: ''
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.base_field_override.comment.comment.status.yml
+++ b/config/core.base_field_override.comment.comment.status.yml
@@ -1,0 +1,22 @@
+uuid: 33fad0d0-d378-463f-88f7-d0b363714142
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.status
+field_name: status
+entity_type: comment
+bundle: comment
+label: 'Publishing status'
+description: 'A boolean indicating whether the comment is published.'
+required: false
+translatable: false
+default_value:
+  -
+    value: 1
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/config/core.base_field_override.comment.comment.subject.yml
+++ b/config/core.base_field_override.comment.comment.subject.yml
@@ -1,0 +1,18 @@
+uuid: a23110c8-db76-4b56-823a-de3f2d62c78f
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.subject
+field_name: subject
+entity_type: comment
+bundle: comment
+label: Subject
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.base_field_override.comment.comment.uid.yml
+++ b/config/core.base_field_override.comment.comment.uid.yml
@@ -1,0 +1,22 @@
+uuid: 72c7391d-cdef-4808-9503-446f4f387082
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+id: comment.comment.uid
+field_name: uid
+entity_type: comment
+bundle: comment
+label: 'User ID'
+description: 'The user ID of the comment author.'
+required: false
+translatable: false
+default_value:
+  -
+    target_id: '0'
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/core.base_field_override.menu_link_content.menu_link_content.changed.yml
+++ b/config/core.base_field_override.menu_link_content.menu_link_content.changed.yml
@@ -1,0 +1,18 @@
+uuid: caeacdaa-ec7c-4172-b8ec-1946cb151fb1
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.changed
+field_name: changed
+entity_type: menu_link_content
+bundle: menu_link_content
+label: Changed
+description: 'The time that the menu link was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/core.base_field_override.menu_link_content.menu_link_content.description.yml
+++ b/config/core.base_field_override.menu_link_content.menu_link_content.description.yml
@@ -1,0 +1,18 @@
+uuid: 9b4ac7a3-f800-4d1b-8ada-d4f34f0dfca2
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.description
+field_name: description
+entity_type: menu_link_content
+bundle: menu_link_content
+label: Description
+description: 'Shown when hovering over the menu link.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.base_field_override.menu_link_content.menu_link_content.title.yml
+++ b/config/core.base_field_override.menu_link_content.menu_link_content.title.yml
@@ -1,0 +1,18 @@
+uuid: ed1bbd37-a1d0-4a4f-9bde-dc6e6eafd636
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_link_content
+id: menu_link_content.menu_link_content.title
+field_name: title
+entity_type: menu_link_content
+bundle: menu_link_content
+label: 'Menu link title'
+description: 'The text to be used for this link in the menu.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.base_field_override.node.speaker.changed.yml
+++ b/config/core.base_field_override.node.speaker.changed.yml
@@ -1,0 +1,18 @@
+uuid: 2e0d4d87-8d1d-4c8a-876e-d4aa290bcc31
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speaker
+id: node.speaker.changed
+field_name: changed
+entity_type: node
+bundle: speaker
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/core.base_field_override.node.speaker.created.yml
+++ b/config/core.base_field_override.node.speaker.created.yml
@@ -1,0 +1,18 @@
+uuid: c8509012-e2c9-4c93-8310-318d95d711bd
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speaker
+id: node.speaker.created
+field_name: created
+entity_type: node
+bundle: speaker
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/core.base_field_override.node.speaker.menu_link.yml
+++ b/config/core.base_field_override.node.speaker.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: d23e5d55-2900-4694-939f-4fcbdd2063e1
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speaker
+id: node.speaker.menu_link
+field_name: menu_link
+entity_type: node
+bundle: speaker
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/core.base_field_override.node.speaker.path.yml
+++ b/config/core.base_field_override.node.speaker.path.yml
@@ -1,0 +1,20 @@
+uuid: 88a58743-eea6-4d81-adc6-a77a297ca43b
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speaker
+  module:
+    - path
+id: node.speaker.path
+field_name: path
+entity_type: node
+bundle: speaker
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/core.base_field_override.node.speaker.status.yml
+++ b/config/core.base_field_override.node.speaker.status.yml
@@ -1,20 +1,20 @@
-uuid: 2ef10f22-1e1b-42a3-a754-5ac1753a9a24
+uuid: 894d1589-66de-43b0-ae1f-8a0d499c8c61
 langcode: en
 status: true
 dependencies:
   config:
     - node.type.speaker
-id: node.speaker.promote
-field_name: promote
+id: node.speaker.status
+field_name: status
 entity_type: node
 bundle: speaker
-label: 'Promoted to front page'
-description: ''
+label: 'Publishing status'
+description: 'A boolean indicating whether the node is published.'
 required: false
 translatable: false
 default_value:
   -
-    value: 0
+    value: 1
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/config/core.base_field_override.node.speaker.sticky.yml
+++ b/config/core.base_field_override.node.speaker.sticky.yml
@@ -1,14 +1,14 @@
-uuid: 2ef10f22-1e1b-42a3-a754-5ac1753a9a24
+uuid: 21416a5e-88a3-4b9c-97a9-41b952150d9d
 langcode: en
 status: true
 dependencies:
   config:
     - node.type.speaker
-id: node.speaker.promote
-field_name: promote
+id: node.speaker.sticky
+field_name: sticky
 entity_type: node
 bundle: speaker
-label: 'Promoted to front page'
+label: 'Sticky at top of lists'
 description: ''
 required: false
 translatable: false

--- a/config/core.base_field_override.node.speaker.title.yml
+++ b/config/core.base_field_override.node.speaker.title.yml
@@ -1,14 +1,14 @@
-uuid: 3c4cecb9-ff95-4f10-9096-0ae80dc24fb8
+uuid: 5105a68c-124f-4842-8fa4-326142593265
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.sponsor
-id: node.sponsor.title
+    - node.type.speaker
+id: node.speaker.title
 field_name: title
 entity_type: node
-bundle: sponsor
-label: Name
+bundle: speaker
+label: Title
 description: ''
 required: true
 translatable: false

--- a/config/core.base_field_override.node.speaker.uid.yml
+++ b/config/core.base_field_override.node.speaker.uid.yml
@@ -1,0 +1,20 @@
+uuid: 3a2f239d-3f11-4bfe-9c98-d6ac91ad0d17
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.speaker
+id: node.speaker.uid
+field_name: uid
+entity_type: node
+bundle: speaker
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/core.base_field_override.node.sponsor.changed.yml
+++ b/config/core.base_field_override.node.sponsor.changed.yml
@@ -1,0 +1,18 @@
+uuid: a3cf815f-f875-4e7c-8759-e115ddcfd6ea
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+id: node.sponsor.changed
+field_name: changed
+entity_type: node
+bundle: sponsor
+label: Changed
+description: 'The time that the node was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/core.base_field_override.node.sponsor.created.yml
+++ b/config/core.base_field_override.node.sponsor.created.yml
@@ -1,0 +1,18 @@
+uuid: bb87d20a-d962-4130-b122-b303f35eda2c
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+id: node.sponsor.created
+field_name: created
+entity_type: node
+bundle: sponsor
+label: 'Authored on'
+description: 'The time that the node was created.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: created

--- a/config/core.base_field_override.node.sponsor.menu_link.yml
+++ b/config/core.base_field_override.node.sponsor.menu_link.yml
@@ -1,0 +1,20 @@
+uuid: de9a6dce-b98f-45a7-b6e6-96eaf0c74304
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+id: node.sponsor.menu_link
+field_name: menu_link
+entity_type: node
+bundle: sponsor
+label: 'Menu link'
+description: 'Computed menu link for the node (only available during node saving).'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/core.base_field_override.node.sponsor.path.yml
+++ b/config/core.base_field_override.node.sponsor.path.yml
@@ -1,18 +1,20 @@
-uuid: 3c4cecb9-ff95-4f10-9096-0ae80dc24fb8
+uuid: d2aa2999-c9d1-4ab9-8d66-e10bea145ae5
 langcode: en
 status: true
 dependencies:
   config:
     - node.type.sponsor
-id: node.sponsor.title
-field_name: title
+  module:
+    - path
+id: node.sponsor.path
+field_name: path
 entity_type: node
 bundle: sponsor
-label: Name
+label: 'URL alias'
 description: ''
-required: true
+required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }
-field_type: string
+field_type: path

--- a/config/core.base_field_override.node.sponsor.status.yml
+++ b/config/core.base_field_override.node.sponsor.status.yml
@@ -1,20 +1,20 @@
-uuid: a8b0a14c-6b27-4927-bc3c-955a35730e12
+uuid: 68eca9ff-c3ab-4b5c-b289-23f35c4cc5b5
 langcode: en
 status: true
 dependencies:
   config:
     - node.type.sponsor
-id: node.sponsor.promote
-field_name: promote
+id: node.sponsor.status
+field_name: status
 entity_type: node
 bundle: sponsor
-label: 'Promoted to front page'
-description: ''
+label: 'Publishing status'
+description: 'A boolean indicating whether the node is published.'
 required: false
 translatable: false
 default_value:
   -
-    value: 0
+    value: 1
 default_value_callback: ''
 settings:
   on_label: 'On'

--- a/config/core.base_field_override.node.sponsor.sticky.yml
+++ b/config/core.base_field_override.node.sponsor.sticky.yml
@@ -1,14 +1,14 @@
-uuid: 2ef10f22-1e1b-42a3-a754-5ac1753a9a24
+uuid: f2ad5bb4-728a-4dfc-850f-4f95240ddceb
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.speaker
-id: node.speaker.promote
-field_name: promote
+    - node.type.sponsor
+id: node.sponsor.sticky
+field_name: sticky
 entity_type: node
-bundle: speaker
-label: 'Promoted to front page'
+bundle: sponsor
+label: 'Sticky at top of lists'
 description: ''
 required: false
 translatable: false

--- a/config/core.base_field_override.node.sponsor.uid.yml
+++ b/config/core.base_field_override.node.sponsor.uid.yml
@@ -1,0 +1,20 @@
+uuid: 87c1efd1-ba0f-4c79-9d4c-9a002f1c75f2
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+id: node.sponsor.uid
+field_name: uid
+entity_type: node
+bundle: sponsor
+label: 'Authored by'
+description: 'The username of the content author.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: 'Drupal\node\Entity\Node::getCurrentUserId'
+settings:
+  handler: default
+  handler_settings: {  }
+field_type: entity_reference

--- a/config/core.base_field_override.shortcut.default.title.yml
+++ b/config/core.base_field_override.shortcut.default.title.yml
@@ -1,15 +1,15 @@
-uuid: 3c4cecb9-ff95-4f10-9096-0ae80dc24fb8
+uuid: 07823847-d8ff-4b3e-a9c8-b74174e5e737
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.sponsor
-id: node.sponsor.title
+    - shortcut.set.default
+id: shortcut.default.title
 field_name: title
-entity_type: node
-bundle: sponsor
+entity_type: shortcut
+bundle: default
 label: Name
-description: ''
+description: 'The name of the shortcut.'
 required: true
 translatable: false
 default_value: {  }

--- a/config/core.base_field_override.taxonomy_term.tags.changed.yml
+++ b/config/core.base_field_override.taxonomy_term.tags.changed.yml
@@ -1,0 +1,18 @@
+uuid: 36bf2d06-b865-401b-a214-2713ced8c834
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.changed
+field_name: changed
+entity_type: taxonomy_term
+bundle: tags
+label: Changed
+description: 'The time that the term was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/core.base_field_override.taxonomy_term.tags.description.yml
+++ b/config/core.base_field_override.taxonomy_term.tags.description.yml
@@ -1,0 +1,20 @@
+uuid: 8384a504-c4e1-4b3f-b7cf-a401aeaace93
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - text
+id: taxonomy_term.tags.description
+field_name: description
+entity_type: taxonomy_term
+bundle: tags
+label: Description
+description: 'A description of the term.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/config/core.base_field_override.taxonomy_term.tags.name.yml
+++ b/config/core.base_field_override.taxonomy_term.tags.name.yml
@@ -1,0 +1,18 @@
+uuid: a33e5d7f-561e-4cc2-a4ea-6cd923bd8262
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+id: taxonomy_term.tags.name
+field_name: name
+entity_type: taxonomy_term
+bundle: tags
+label: Name
+description: 'The term name.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/core.base_field_override.taxonomy_term.tags.path.yml
+++ b/config/core.base_field_override.taxonomy_term.tags.path.yml
@@ -1,0 +1,20 @@
+uuid: cd86236f-00eb-49f6-85c6-8d9b0aff917a
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - path
+id: taxonomy_term.tags.path
+field_name: path
+entity_type: taxonomy_term
+bundle: tags
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/core.base_field_override.user.user.changed.yml
+++ b/config/core.base_field_override.user.user.changed.yml
@@ -1,0 +1,18 @@
+uuid: 1356dd29-af49-49ea-bd2e-d96c1c3b47c2
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.user.changed
+field_name: changed
+entity_type: user
+bundle: user
+label: Changed
+description: 'The time that the user was last edited.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: changed

--- a/config/core.base_field_override.user.user.path.yml
+++ b/config/core.base_field_override.user.user.path.yml
@@ -1,0 +1,19 @@
+uuid: c8c21dfe-5b1f-4971-9026-a520065ffecf
+langcode: en
+status: true
+dependencies:
+  module:
+    - path
+    - user
+id: user.user.path
+field_name: path
+entity_type: user
+bundle: user
+label: 'URL alias'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: path

--- a/config/field.field.comment.comment.comment_body.yml
+++ b/config/field.field.comment.comment.comment_body.yml
@@ -16,7 +16,7 @@ bundle: comment
 label: Comment
 description: ''
 required: true
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/config/field.field.node.article.field_image.yml
+++ b/config/field.field.node.article.field_image.yml
@@ -6,7 +6,14 @@ dependencies:
     - field.storage.node.field_image
     - node.type.article
   module:
+    - content_translation
     - image
+third_party_settings:
+  content_translation:
+    translation_sync:
+      alt: alt
+      title: title
+      file: '0'
 _core:
   default_config_hash: tgJzhA7Swh4M_gWU5FwFe5lPxPj5rebpMbvhpdNrERs
 id: node.article.field_image

--- a/config/field.field.node.speaker.body.yml
+++ b/config/field.field.node.speaker.body.yml
@@ -16,7 +16,7 @@ bundle: speaker
 label: Bio
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/field.field.user.user.user_picture.yml
+++ b/config/field.field.user.user.user_picture.yml
@@ -16,7 +16,7 @@ bundle: user
 label: Picture
 description: 'Your virtual face or picture.'
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/config/language.content_settings.block_content.basic.yml
+++ b/config/language.content_settings.block_content.basic.yml
@@ -1,0 +1,16 @@
+uuid: 44b3b1a9-f29b-459b-af7a-fbd08ce42329
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: block_content.basic
+target_entity_type_id: block_content
+target_bundle: basic
+default_langcode: site_default
+language_alterable: true

--- a/config/language.content_settings.comment.comment.yml
+++ b/config/language.content_settings.comment.comment.yml
@@ -1,16 +1,16 @@
-uuid: c2ece097-882a-446e-94fa-20bdd3ae1f9a
+uuid: 0e0648a9-e9ba-45c2-97ed-0b442e81f2ce
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.sponsor
+    - comment.type.comment
   module:
     - content_translation
 third_party_settings:
   content_translation:
     enabled: false
-id: node.sponsor
-target_entity_type_id: node
-target_bundle: sponsor
+id: comment.comment
+target_entity_type_id: comment
+target_bundle: comment
 default_langcode: site_default
 language_alterable: false

--- a/config/language.content_settings.contact_message.feedback.yml
+++ b/config/language.content_settings.contact_message.feedback.yml
@@ -1,0 +1,11 @@
+uuid: 67febd54-f338-4af3-a1cd-c2ea21ce25a6
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.feedback
+id: contact_message.feedback
+target_entity_type_id: contact_message
+target_bundle: feedback
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.contact_message.personal.yml
+++ b/config/language.content_settings.contact_message.personal.yml
@@ -1,0 +1,11 @@
+uuid: dc55b20d-52f6-4c63-9d73-0ccb0a9db78e
+langcode: en
+status: true
+dependencies:
+  config:
+    - contact.form.personal
+id: contact_message.personal
+target_entity_type_id: contact_message
+target_bundle: personal
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.file.file.yml
+++ b/config/language.content_settings.file.file.yml
@@ -1,0 +1,11 @@
+uuid: cc84df3c-2869-47d7-bf83-afa5c016d97f
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+id: file.file
+target_entity_type_id: file
+target_bundle: file
+default_langcode: site_default
+language_alterable: false

--- a/config/language.content_settings.menu_link_content.menu_link_content.yml
+++ b/config/language.content_settings.menu_link_content.menu_link_content.yml
@@ -1,16 +1,15 @@
-uuid: c2ece097-882a-446e-94fa-20bdd3ae1f9a
+uuid: ef515021-a29a-4a79-9c14-fdd2c4b52712
 langcode: en
 status: true
 dependencies:
-  config:
-    - node.type.sponsor
   module:
     - content_translation
+    - menu_link_content
 third_party_settings:
   content_translation:
     enabled: false
-id: node.sponsor
-target_entity_type_id: node
-target_bundle: sponsor
+id: menu_link_content.menu_link_content
+target_entity_type_id: menu_link_content
+target_bundle: menu_link_content
 default_langcode: site_default
 language_alterable: false

--- a/config/language.content_settings.node.article.yml
+++ b/config/language.content_settings.node.article.yml
@@ -1,16 +1,16 @@
-uuid: c2ece097-882a-446e-94fa-20bdd3ae1f9a
+uuid: e2e2064d-4ee2-44e7-abb5-6d8a357558b0
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.sponsor
+    - node.type.article
   module:
     - content_translation
 third_party_settings:
   content_translation:
-    enabled: false
-id: node.sponsor
+    enabled: true
+id: node.article
 target_entity_type_id: node
-target_bundle: sponsor
+target_bundle: article
 default_langcode: site_default
-language_alterable: false
+language_alterable: true

--- a/config/language.content_settings.node.speaker.yml
+++ b/config/language.content_settings.node.speaker.yml
@@ -4,6 +4,11 @@ status: true
 dependencies:
   config:
     - node.type.speaker
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
 id: node.speaker
 target_entity_type_id: node
 target_bundle: speaker

--- a/config/language.content_settings.shortcut.default.yml
+++ b/config/language.content_settings.shortcut.default.yml
@@ -1,16 +1,16 @@
-uuid: c2ece097-882a-446e-94fa-20bdd3ae1f9a
+uuid: bd1fad4f-a79d-4f89-ab13-61201c4e7768
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.sponsor
+    - shortcut.set.default
   module:
     - content_translation
 third_party_settings:
   content_translation:
     enabled: false
-id: node.sponsor
-target_entity_type_id: node
-target_bundle: sponsor
+id: shortcut.default
+target_entity_type_id: shortcut
+target_bundle: default
 default_langcode: site_default
 language_alterable: false

--- a/config/language.content_settings.taxonomy_term.tags.yml
+++ b/config/language.content_settings.taxonomy_term.tags.yml
@@ -1,16 +1,16 @@
-uuid: c2ece097-882a-446e-94fa-20bdd3ae1f9a
+uuid: 02539bb6-89fe-48ec-a6ea-5f2bbb73b0cd
 langcode: en
 status: true
 dependencies:
   config:
-    - node.type.sponsor
+    - taxonomy.vocabulary.tags
   module:
     - content_translation
 third_party_settings:
   content_translation:
     enabled: false
-id: node.sponsor
-target_entity_type_id: node
-target_bundle: sponsor
+id: taxonomy_term.tags
+target_entity_type_id: taxonomy_term
+target_bundle: tags
 default_langcode: site_default
 language_alterable: false

--- a/config/language.content_settings.user.user.yml
+++ b/config/language.content_settings.user.user.yml
@@ -1,16 +1,15 @@
-uuid: c2ece097-882a-446e-94fa-20bdd3ae1f9a
+uuid: 0752a370-7ec9-43d4-8102-12ddddd45c94
 langcode: en
 status: true
 dependencies:
-  config:
-    - node.type.sponsor
   module:
     - content_translation
+    - user
 third_party_settings:
   content_translation:
     enabled: false
-id: node.sponsor
-target_entity_type_id: node
-target_bundle: sponsor
+id: user.user
+target_entity_type_id: user
+target_bundle: user
 default_langcode: site_default
 language_alterable: false

--- a/config/node.type.page.yml
+++ b/config/node.type.page.yml
@@ -1,7 +1,14 @@
 uuid: c8ab5c0d-a209-4f48-b64c-9e331a884494
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
 _core:
   default_config_hash: zhtPXoRcC6REiepM0k16zw__FDW5YOXDR6U2WlldTrs
 name: 'Basic page'


### PR DESCRIPTION
@nuez @samuelsolis this adds support to translate articles and content blocks. We need this in Prod in order to translate these. I have tested it locally so, if you agree, please merge and I will make a new release and deploy to Prod.