### PR TITLE
Hide user login block from header

### DIFF
--- a/config/block.block.dcamp_2017_theme_account_menu.yml
+++ b/config/block.block.dcamp_2017_theme_account_menu.yml
@@ -13,7 +13,7 @@ _core:
 id: dcamp_2017_theme_account_menu
 theme: dcamp_2017_theme
 region: '-1'
-weight: -1
+weight: 0
 provider: null
 plugin: 'system_menu_block:account'
 settings:

--- a/config/block.block.dcamp_2017_theme_branding.yml
+++ b/config/block.block.dcamp_2017_theme_branding.yml
@@ -11,7 +11,7 @@ _core:
 id: dcamp_2017_theme_branding
 theme: dcamp_2017_theme
 region: '-1'
-weight: -4
+weight: -3
 provider: null
 plugin: system_branding_block
 settings:

--- a/config/block.block.dcamp_2017_theme_messages.yml
+++ b/config/block.block.dcamp_2017_theme_messages.yml
@@ -11,7 +11,7 @@ _core:
 id: dcamp_2017_theme_messages
 theme: dcamp_2017_theme
 region: '-1'
-weight: -3
+weight: -2
 provider: null
 plugin: system_messages_block
 settings:

--- a/config/block.block.dcamp_2017_theme_page_title.yml
+++ b/config/block.block.dcamp_2017_theme_page_title.yml
@@ -11,7 +11,7 @@ _core:
 id: dcamp_2017_theme_page_title
 theme: dcamp_2017_theme
 region: '-1'
-weight: 0
+weight: -6
 provider: null
 plugin: page_title_block
 settings:

--- a/config/block.block.dcamp_2017_theme_powered.yml
+++ b/config/block.block.dcamp_2017_theme_powered.yml
@@ -11,7 +11,7 @@ _core:
 id: dcamp_2017_theme_powered
 theme: dcamp_2017_theme
 region: '-1'
-weight: -6
+weight: -5
 provider: null
 plugin: system_powered_by_block
 settings:

--- a/config/block.block.dcamp_2017_theme_search.yml
+++ b/config/block.block.dcamp_2017_theme_search.yml
@@ -11,7 +11,7 @@ _core:
 id: dcamp_2017_theme_search
 theme: dcamp_2017_theme
 region: '-1'
-weight: -5
+weight: -4
 provider: null
 plugin: search_form_block
 settings:

--- a/config/block.block.dcamp_2017_theme_tools.yml
+++ b/config/block.block.dcamp_2017_theme_tools.yml
@@ -13,7 +13,7 @@ _core:
 id: dcamp_2017_theme_tools
 theme: dcamp_2017_theme
 region: '-1'
-weight: -2
+weight: -1
 provider: null
 plugin: 'system_menu_block:tools'
 settings:

--- a/config/block.block.userlogin.yml
+++ b/config/block.block.userlogin.yml
@@ -1,6 +1,6 @@
 uuid: aaacd023-a4d2-4f78-ad68-63571604ac75
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - user
@@ -8,8 +8,8 @@ dependencies:
     - dcamp_2017_theme
 id: userlogin
 theme: dcamp_2017_theme
-region: header
-weight: -7
+region: '-1'
+weight: 1
 provider: null
 plugin: user_login_block
 settings:


### PR DESCRIPTION
Because there are only admin accounts in the site

![image](https://cloud.githubusercontent.com/assets/108130/24601817/a34e6aa2-185a-11e7-9b71-0ac013f929d4.png)
