### PR TITLE
163 individual sponsors

### DIFF
--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -15,6 +15,7 @@ module:
   dblog: 0
   dcamp: 0
   dcamp_api: 0
+  dcamp_attendees: 0
   dcamp_sessions: 0
   dynamic_page_cache: 0
   editor: 0

--- a/web/modules/custom/dcamp/dcamp.install
+++ b/web/modules/custom/dcamp/dcamp.install
@@ -404,3 +404,10 @@ function dcamp_update_8113() {
 function dcamp_update_8114() {
   \Drupal::service('module_installer')->install(['dcamp_api']);
 }
+
+/**
+ * Install attendees module.
+ */
+function dcamp_update_8115() {
+  \Drupal::service('module_installer')->install(['dcamp_attendees']);
+}

--- a/web/modules/custom/dcamp_attendees/dcamp_attendees.info.yml
+++ b/web/modules/custom/dcamp_attendees/dcamp_attendees.info.yml
@@ -1,0 +1,5 @@
+name: DrupalCamp Attendees
+description: Fetches attendees from EventBrite
+package: dcamp
+type: module
+core: 8.x

--- a/web/modules/custom/dcamp_attendees/dcamp_attendees.services.yml
+++ b/web/modules/custom/dcamp_attendees/dcamp_attendees.services.yml
@@ -1,0 +1,3 @@
+services:
+  dcamp_attendees.eventbrite:
+    class: Drupal\dcamp_attendees\EventBriteService

--- a/web/modules/custom/dcamp_attendees/fixtures/individual_sponsors.json
+++ b/web/modules/custom/dcamp_attendees/fixtures/individual_sponsors.json
@@ -1,0 +1,229 @@
+[
+  {
+    "team": null,
+    "id": "770810925",
+    "changed": "2017-04-04T08:07:41Z",
+    "created": "2017-04-04T08:03:03Z",
+    "quantity": 1,
+    "profile": {
+      "first_name": "Jes\u00fas",
+      "last_name": "S\u00e1nchez Balsera",
+      "addresses": {
+        "home": {},
+        "ship": {},
+        "work": {},
+        "bill": {}
+      },
+      "gender": "male",
+      "company": "Cocomore AG",
+      "name": "Jes\u00fas S\u00e1nchez Balsera"
+    },
+    "answers": [
+      {
+        "question": "Deseo ser colaborador del evento / I want to be a collaborator",
+        "type": "multiple_choice",
+        "question_id": "15011692"
+      },
+      {
+        "answer": "XXL chico / male",
+        "question": "Camiseta / T-shirt",
+        "type": "multiple_choice",
+        "question_id": "15011702"
+      },
+      {
+        "answer": "https://www.drupal.org/files/styles/grid-2/public/user-pictures/picture-1483672-1461942714.jpg",
+        "question": "Url de foto / Photo url",
+        "type": "text",
+        "question_id": "15019980"
+      },
+      {
+        "answer": "https://www.twitter.com/jsbalsera",
+        "question": "Twitter",
+        "type": "text",
+        "question_id": "15019982"
+      },
+      {
+        "answer": "jsbalsera",
+        "question": "Usuario de drupal.org / Drupal.org username",
+        "type": "text",
+        "question_id": "15019986"
+      }
+    ],
+    "checked_in": false,
+    "cancelled": false,
+    "refunded": false,
+    "affiliate": "es2",
+    "status": "Attending",
+    "ticket_class_name": "Patrocinador individual",
+  },
+  {
+    "team": null,
+    "changed": "2017-04-04T08:39:28Z",
+    "created": "2017-04-04T08:39:26Z",
+    "quantity": 1,
+    "profile": {
+      "first_name": "Pablo",
+      "last_name": "L\u00f3pez",
+      "addresses": {
+        "home": {},
+        "ship": {},
+        "work": {},
+        "bill": {}
+      },
+      "gender": "hombre",
+      "company": "Bluespark",
+      "name": "Pablo L\u00f3pez"
+    },
+    "answers": [
+      {
+        "answer": "Dese ser colaborador del evento (controlar tiempo en las charlas, etc).",
+        "question": "Deseo ser colaborador del evento / I want to be a collaborator",
+        "type": "multiple_choice",
+        "question_id": "15011692"
+      },
+      {
+        "answer": "L chico / male",
+        "question": "Camiseta / T-shirt",
+        "type": "multiple_choice",
+        "question_id": "15011702"
+      },
+      {
+        "answer": "https://seville2017.drupaldays.org/sites/default/files/styles/crop_150x150/public/2017-02/profile_porto.jpg",
+        "question": "Url de foto / Photo url",
+        "type": "text",
+        "question_id": "15019980"
+      },
+      {
+        "answer": "plopesc",
+        "question": "Twitter",
+        "type": "text",
+        "question_id": "15019982"
+      },
+      {
+        "answer": "plopesc",
+        "question": "Usuario de drupal.org / Drupal.org username",
+        "type": "text",
+        "question_id": "15019986"
+      }
+    ],
+    "checked_in": false,
+    "cancelled": false,
+    "refunded": false,
+    "affiliate": null,
+    "status": "Attending",
+    "ticket_class_name": "Patrocinador individual",
+  },
+  {
+    "team": null,
+    "id": "770818756",
+    "changed": "2017-04-04T08:43:52Z",
+    "created": "2017-04-04T08:43:50Z",
+    "quantity": 1,
+    "profile": {
+      "first_name": "Ignacio",
+      "last_name": "S\u00e1nchez Holgueras",
+      "addresses": {
+        "home": {},
+        "ship": {},
+        "work": {},
+        "bill": {}
+      },
+      "gender": "hombre",
+      "company": "Ignacio S\u00e1nchez",
+      "name": "Ignacio S\u00e1nchez Holgueras"
+    },
+    "answers": [
+      {
+        "answer": "Dese ser colaborador del evento (controlar tiempo en las charlas, etc).",
+        "question": "Deseo ser colaborador del evento / I want to be a collaborator",
+        "type": "multiple_choice",
+        "question_id": "15011692"
+      },
+      {
+        "answer": "L chico / male",
+        "question": "Camiseta / T-shirt",
+        "type": "multiple_choice",
+        "question_id": "15011702"
+      },
+      {
+        "answer": "https://pbs.twimg.com/profile_images/835052963743825920/WPlEoErZ.jpg",
+        "question": "Url de foto / Photo url",
+        "type": "text",
+        "question_id": "15019980"
+      },
+      {
+        "answer": "https://twitter.com/isholgueras",
+        "question": "Twitter",
+        "type": "text",
+        "question_id": "15019982"
+      },
+      {
+        "answer": "https://www.drupal.org/u/isholgueras",
+        "question": "Usuario de drupal.org / Drupal.org username",
+        "type": "text",
+        "question_id": "15019986"
+      }
+    ],
+    "checked_in": false,
+    "cancelled": false,
+    "refunded": false,
+    "affiliate": null,
+    "status": "Attending",
+    "ticket_class_name": "Patrocinador individual",
+  },
+  {
+    "team": null,
+    "changed": "2017-04-05T08:18:50Z",
+    "created": "2017-04-05T08:18:48Z",
+    "quantity": 1,
+    "profile": {
+      "first_name": "Amaranto",
+      "last_name": "del Barrio",
+      "addresses": {
+        "home": {},
+        "ship": {},
+        "work": {},
+        "bill": {}
+      },
+      "gender": "hombre",
+      "company": "Emergya",
+      "name": "Amaranto del Barrio"
+    },
+    "answers": [
+      {
+        "question": "Deseo ser colaborador del evento / I want to be a collaborator",
+        "type": "multiple_choice",
+        "question_id": "15011692"
+      },
+      {
+        "answer": "XL chico / male",
+        "question": "Camiseta / T-shirt",
+        "type": "multiple_choice",
+        "question_id": "15011702"
+      },
+      {
+        "question": "Url de foto / Photo url",
+        "type": "text",
+        "question_id": "15019980"
+      },
+      {
+        "answer": "https://twitter.com/onubense1989",
+        "question": "Twitter",
+        "type": "text",
+        "question_id": "15019982"
+      },
+      {
+        "answer": "abarrio",
+        "question": "Usuario de drupal.org / Drupal.org username",
+        "type": "text",
+        "question_id": "15019986"
+      }
+    ],
+    "checked_in": false,
+    "cancelled": false,
+    "refunded": false,
+    "affiliate": null,
+    "status": "Attending",
+    "ticket_class_name": "Patrocinador individual",
+  }
+]

--- a/web/modules/custom/dcamp_attendees/src/Entity/IndividualSponsor.php
+++ b/web/modules/custom/dcamp_attendees/src/Entity/IndividualSponsor.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Drupal\dcamp_attendees\Entity;
+
+class IndividualSponsor {
+
+
+  /**
+   * The full name.
+   *
+   * @var string
+   */
+  protected $name;
+
+  /**
+   * The headshot.
+   *
+   * @var string
+   */
+  protected $headshot;
+
+  /**
+   * The Twitter profile.
+   * @var string
+   */
+  protected $twitter;
+
+  /**
+   * The Drupal.org profile.
+   *
+   * @var string
+   */
+  protected $drupal;
+
+  /**
+   * IndividualSponsor constructor.
+   *
+   * @param stdClass $individual_sponsor
+   *   The raw object from EventBrite.
+   */
+  public function __construct($individual_sponsor) {
+    $this->name = $individual_sponsor->profile->name;
+    foreach ($individual_sponsor->answers as $answer) {
+      if (!empty($answer->answer)) {
+        if ($answer->question_id == '15019980') {
+          $this->headshot = $answer->answer;
+        }
+        elseif ($answer->question_id == '15019982') {
+          $this->twitter = $answer->answer;
+        }
+        elseif ($answer->question_id == '15019986') {
+          $this->drupal = $answer->answer;
+        }
+      }
+    }
+  }
+
+  /**
+   * @return string
+   */
+  public function getName() {
+    return $this->name;
+  }
+
+  /**
+   * @param string $name
+   */
+  public function setName(string $name) {
+    $this->name = $name;
+  }
+
+  /**
+   * @return string
+   */
+  public function getHeadshot() {
+    return $this->headshot;
+  }
+
+  /**
+   * @param string $headshot
+   */
+  public function setHeadshot(string $headshot) {
+    $this->headshot = $headshot;
+  }
+
+  /**
+   * @return string
+   */
+  public function getTwitter() {
+    return $this->twitter;
+  }
+
+  /**
+   * @param string $twitter
+   */
+  public function setTwitter(string $twitter) {
+    $this->twitter = $twitter;
+  }
+
+  /**
+   * @return string
+   */
+  public function getDrupal() {
+    return $this->drupal;
+  }
+
+  /**
+   * @param string $drupal
+   */
+  public function setDrupal(string $drupal) {
+    $this->drupal = $drupal;
+  }
+
+  /**
+   * Returns the Twitter or Drupal Link URL.
+   *
+   * @return string
+   *   A URL to the profile or an empty string if there is no link.
+   */
+  public function getProfileUrl() {
+    $url = '';
+
+    if (!empty($this->getTwitter())) {
+      $url = 'https://twitter.com/' . $this->extractNickname($this->getTwitter());
+    }
+    elseif (!empty($this->getDrupal())) {
+      $url = 'https://www.drupal.org/u/' . $this->extractNickname($this->getDrupal());
+    }
+
+    return $url;
+  }
+
+  /**
+   * Returns the Twitter or Drupal nickname.
+   *
+   * @return string
+   *   A URL to the profile or an empty string if there is no nickname.
+   */
+  public function getNickname() {
+    $nickname = '';
+
+    if (!empty($this->getTwitter())) {
+      $nickname = $this->extractNickname($this->getTwitter());
+      $nickname = '@' . $nickname;
+    }
+    elseif (!empty($this->getDrupal())) {
+      $nickname = $this->extractNickname($this->getDrupal());
+    }
+
+    return $nickname;
+  }
+
+  /**
+   * Removes the URL from a profile URL and keeps the nickname.
+   *
+   * @param string $url
+   *   The profile URL.
+   *
+   * @return string
+   *   The nickname.
+   */
+  private function extractNickname($url) {
+    $nickname = $url;
+
+    // First extract everything until the last forwardslash.
+    $slash_pos = strrpos($nickname, '/');
+    if ($slash_pos) {
+      $nickname = substr($nickname, $slash_pos + 1);
+    }
+
+    // Next, remove the @ symbol that Twitter nicknames may have.
+    $nickname = str_replace('@', '', $nickname);
+
+    return $nickname;
+  }
+
+}

--- a/web/modules/custom/dcamp_attendees/src/EventBriteService.php
+++ b/web/modules/custom/dcamp_attendees/src/EventBriteService.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\dcamp_attendees;
+
+use Drupal\dcamp_attendees\Entity\IndividualSponsor;
+
+class EventBriteService {
+
+  /**
+   * Return the list of individual sponsors
+   *
+   * @return \Drupal\dcamp_attendees\Entity\IndividualSponsor[]
+   *   Array of IndividualSponsor objects
+   */
+  public function getIndividualSponsors() {
+    $config = \Drupal::config('dcamp_attendees.settings');
+
+    // Check if we are in developer mode.
+    if ($config->get('debugging')) {
+      $path = \Drupal::service('module_handler')->getModule('dcamp_attendees')->getPath();
+      $individual_sponsors = file_get_contents($path . '/fixtures/individual_sponsors.json');
+      $individual_sponsors = json_decode($individual_sponsors);
+      foreach ($individual_sponsors as $attendee) {
+        $individual_sponsors[] = new IndividualSponsor($attendee);
+      }
+    }
+
+    // Request the list of attendees to EventBrite and filter individual sponsors.
+    // TODO take into account paging as the following request returns just the
+    // first 50 results.
+    $client = \Drupal::httpClient();
+    $response = $client->request('GET', 'https://www.eventbriteapi.com/v3/events/' . $config->get('event_id') . '/attendees', [
+      'headers' => [
+        'Authorization' => 'Bearer ' . $config->get('oauth_token'),
+      ]
+    ]);
+
+    if ($response->getStatusCode() !== 200) {
+      throw new \RuntimeException('Bad response from EventBrite');
+    }
+
+    $response_data = json_decode($response->getBody());
+    $individual_sponsors = [];
+    foreach ($response_data->attendees as $attendee) {
+      if ($attendee->ticket_class_name = 'Patrocinador individual') {
+        $individual_sponsors[] = new IndividualSponsor($attendee);
+      }
+    }
+
+    // @TODO cache this result.
+    return $individual_sponsors;
+  }
+
+}

--- a/web/sites/default/default.settings.local.php
+++ b/web/sites/default/default.settings.local.php
@@ -52,12 +52,12 @@ $settings['extension_discovery_scan_tests'] = TRUE;
 $settings['rebuild_access'] = TRUE;
 $settings['skip_permissions_hardening'] = TRUE;
 
-// Session settings
+// Session settings.
 $config['dcamp_sessions.settings'] = [
-  'service_account_file' => 'full-path-to-service-account.json',
-  'spreadsheet_id' => 'identifier-from-spreadsheet-in-URL',
-  'spreadsheet_range' => 'sheet-name',
-  // Set this to FALSE if you have the above and want to see real data.
   'debugging' => TRUE,
 ];
 
+// Attendees settings.
+$config['dcamp_attendees.settings'] = [
+  'debugging' => TRUE,
+];

--- a/web/themes/dcamp_2017_theme/dcamp_2017_theme.theme
+++ b/web/themes/dcamp_2017_theme/dcamp_2017_theme.theme
@@ -17,14 +17,19 @@ function dcamp_2017_theme_preprocess(&$variables, $hook) {
   $variables['path_to_dcamp_2017_theme'] = base_path() . drupal_get_path('theme', 'dcamp_2017_theme');
 }
 
+/**
+ * @file
+ * Provides hook implementations for testing purposes.
+ */
 
-function dcamp_2017_theme_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if ("user_login_form" == $form_id) {
-$form['pass']['#title'] = t('Password. @link', ['@link' => Link::fromTextAndUrl(t('Did you forget?'), Url::fromUserInput('/user/password'))->toString()]);
-$form['actions']['submit']['#suffix'] = Link::fromTextAndUrl(t("No account?"), Url::fromUserInput('/user/create'))->toString();
-  }
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Adds the list of individual sponsors to the sponsors views block.
+ */
+function dcamp_2017_theme_preprocess_frontpage(&$variables) {
+  $variables['individual_sponsors'] = \Drupal::service('dcamp_attendees.eventbrite')->getIndividualSponsors();
 }
-
 /**
  * Implements hook_theme_suggestions_HOOK_alter().
  */

--- a/web/themes/dcamp_2017_theme/dcamp_2017_theme.theme
+++ b/web/themes/dcamp_2017_theme/dcamp_2017_theme.theme
@@ -18,11 +18,6 @@ function dcamp_2017_theme_preprocess(&$variables, $hook) {
 }
 
 /**
- * @file
- * Provides hook implementations for testing purposes.
- */
-
-/**
  * Implements hook_preprocess_HOOK().
  *
  * Adds the list of individual sponsors to the sponsors views block.

--- a/web/themes/dcamp_2017_theme/templates/frontpage.html.twig
+++ b/web/themes/dcamp_2017_theme/templates/frontpage.html.twig
@@ -102,6 +102,16 @@
     <div class="sub">
       <div class="content">
         {{ sponsors }}
+        <h3>Individual sponsors</h3>
+        <ul>
+            {% for individual_sponsor in individual_sponsors %}
+              <li>
+                <img src="{{ individual_sponsor.getHeadshot() }}"/><br/><br/>
+                {{ individual_sponsor.getName() }}<br/><br/>
+                (<a href="{{ individual_sponsor.getProfileUrl() }}" target="_blank">{{ individual_sponsor.getNickname() }}</a>)
+              </li>
+            {% endfor %}
+        </ul>
       </div>
     </div>
   </section>


### PR DESCRIPTION
This PR lists individual sponsors in a way that makes you puke:

![image](https://cloud.githubusercontent.com/assets/108130/24717303/472d25e0-1a32-11e7-9cdd-5ab02abf8d3e.png)

If you want to help making this listing look good, here is how:

1. Checkout this branch.
2. Add the following to `settings.local.php`:
```php
// Attendees settings.
$config['dcamp_attendees.settings'] = [
  'debugging' => TRUE,
];
```
3. Run database updates.
4. Open the homepage. You should see the list of individual sponsors (have a bucket next to you).