### PR TITLE
Change the number of attendees per page.

### DIFF
--- a/web/modules/custom/dcamp_attendees/src/Controller/DcampAttendeesController.php
+++ b/web/modules/custom/dcamp_attendees/src/Controller/DcampAttendeesController.php
@@ -27,7 +27,7 @@ class DcampAttendeesController extends ControllerBase {
    *
    * @var int
    */
-  protected $attendeesPerPage = 50;
+  protected $attendeesPerPage = 48;
 
   /**
    * Lists attendees.


### PR DESCRIPTION
Currently the number of attendees per page is 50, but because the design shows 4 per row there is a blank space at the end of the page. This pull request changes this to a number divisible by 4.