### PR TITLE
Fixes issue #252: Bigger sponsor images so they don't look blurry

### DIFF
--- a/config/image.style.sponsor_logo.yml
+++ b/config/image.style.sponsor_logo.yml
@@ -5,13 +5,13 @@ dependencies: {  }
 _core:
   default_config_hash: hcGGCTt6L4-gcUgBXrQs8sk-_23x5y-ZC10KfvVgkDQ
 name: sponsor_logo
-label: 'Sponsor logo (Heigth: 75)'
+label: 'Sponsor logo'
 effects:
   d12b1ce6-9c5d-4d58-87c8-6da1be8294a6:
     uuid: d12b1ce6-9c5d-4d58-87c8-6da1be8294a6
     id: image_scale
     weight: 1
     data:
-      width: null
-      height: 75
+      width: 300
+      height: 300
       upscale: false


### PR DESCRIPTION
I think if we make the sponsor images bigger, they shouldn't be blurry. We resize them in CSS. I think with max 300px width/height this shouldnt create any performance issues.