### PR TITLE
[#326] Hide company field

### DIFF
--- a/web/modules/custom/dcamp_attendees/templates/attendees-list.html.twig
+++ b/web/modules/custom/dcamp_attendees/templates/attendees-list.html.twig
@@ -42,7 +42,6 @@
                         {%- endif -%}
                     </div>
                     <h2 class="attendee__title">{{ attendee.getName }}</h2>
-                    <h3 class="attendee__company">{{ attendee.getCompany }}</h3>
                     <div class="attendee__social">
                         {% if attendee.getTwitter %}
                             <a class="social-media__link social-media__link--twitter"


### PR DESCRIPTION
We were getting the company field from the payment details, which
shows weird values when the attendee bought the ticket as an
individual.

We have activated the company field at EventBrite. In a few days
we will adjust the code so it shows the right value.