### PR TITLE
Filter attendees

### DIFF
--- a/web/modules/custom/dcamp_attendees/src/Entity/Attendee.php
+++ b/web/modules/custom/dcamp_attendees/src/Entity/Attendee.php
@@ -67,6 +67,13 @@ class Attendee implements JsonSerializable {
   protected $isSpeaker = FALSE;
 
   /**
+   * The order id.
+   *
+   * @var string
+   */
+  protected $orderId;
+
+  /**
    * Attendee constructor.
    *
    * @param stdClass $attendee
@@ -77,6 +84,7 @@ class Attendee implements JsonSerializable {
     $this->name = $attendee->profile->name;
     $this->company = !empty($attendee->profile->company) ? $attendee->profile->company : '';
     $this->ticketClassId = $attendee->ticket_class_id;
+    $this->orderId = $attendee->order_id;
     foreach ($attendee->answers as $answer) {
       if (!empty($answer->answer)) {
         if ($answer->question_id == EventBriteService::QUESTION_HEADSHOT) {
@@ -208,6 +216,20 @@ class Attendee implements JsonSerializable {
    */
   public function setTicketClassId($ticket_class_id) {
     $this->ticketClassId = $ticket_class_id;
+  }
+
+  /**
+   * @return string
+   */
+  public function getOrderId() {
+    return $this->orderId;
+  }
+
+  /**
+   * @param string $orderId
+   */
+  public function setOrderId($orderId) {
+    $this->orderId = $orderId;
   }
 
   /**

--- a/web/modules/custom/dcamp_attendees/templates/attendees-list.html.twig
+++ b/web/modules/custom/dcamp_attendees/templates/attendees-list.html.twig
@@ -42,6 +42,7 @@
                         {%- endif -%}
                     </div>
                     <h2 class="attendee__title">{{ attendee.getName }}</h2>
+                    <h3 class="attendee__company">{{ attendee.getCompany }}</h3>
                     <div class="attendee__social">
                         {% if attendee.getTwitter %}
                             <a class="social-media__link social-media__link--twitter"


### PR DESCRIPTION
If someone bought more than one ticket, we should keep just the first one. Currently there are duplicates at https://2018.drupalcamp.es/attendees/list because we aren't filtering:

![image](https://user-images.githubusercontent.com/108130/37827480-f36047be-2e97-11e8-9876-f2f9b322a166.png)

With this pull request, we only see one attendee instead:

![image](https://user-images.githubusercontent.com/108130/37827564-4cce0ae8-2e98-11e8-89ee-bb1b63bd4997.png)

However, we should promote people who buy more than one ticket, right? I could add a variable that keeps track of how many tickets an attendee has purchased. Is it worth it to highlight this somehow in the listing? Something like:

![image](https://user-images.githubusercontent.com/108130/37827587-63c4b4cc-2e98-11e8-9df3-5ab0279c771e.png)

@ferelx @samuelsolis thoughts?
