### PR TITLE
Highlight speakers and individual sponsors who bought a ticket

### DIFF
--- a/web/modules/custom/dcamp_attendees/src/Controller/DcampAttendeesController.php
+++ b/web/modules/custom/dcamp_attendees/src/Controller/DcampAttendeesController.php
@@ -39,19 +39,19 @@ class DcampAttendeesController extends ControllerBase {
   public function listAttendees() {
     $attendees = \Drupal::service('dcamp_attendees.eventbrite')->getAttendees();
 
-    // Check if this is an API request.
-    if (\Drupal::request()->query->get('_format') == 'json') {
-      // Set the is_speaker flag.
-      $sessions = \Drupal::service('dcamp_sessions.proposals')->getSelected();
-      foreach ($attendees as $attendee) {
-        foreach ($sessions as $session) {
-          if ($attendee->speaksAt($session)) {
-            $attendee->setIsSpeaker(TRUE);
-            break;
-          }
+    // Set the is_speaker flag.
+    $sessions = \Drupal::service('dcamp_sessions.proposals')->getSelected();
+    foreach ($attendees as $attendee) {
+      foreach ($sessions as $session) {
+        if ($attendee->speaksAt($session)) {
+          $attendee->setIsSpeaker(TRUE);
+          break;
         }
       }
+    }
 
+    // Check if this is an API request.
+    if (\Drupal::request()->query->get('_format') == 'json') {
       // Prepare and send response.
       $headers = [
         'max-age' => $this->maxAge,

--- a/web/modules/custom/dcamp_attendees/templates/attendees-list.html.twig
+++ b/web/modules/custom/dcamp_attendees/templates/attendees-list.html.twig
@@ -40,6 +40,9 @@
                         {%- if attendee.isIndividualSponsor -%}
                             <div class="attendee__sponsor">Sponsor</div>
                         {%- endif -%}
+                        {%- if attendee.isSpeaker -%}
+                            <div class="attendee__sponsor">Sponsor</div>
+                        {%- endif -%}
                     </div>
                     <h2 class="attendee__title">{{ attendee.getName }}</h2>
                     <h3 class="attendee__company">{{ attendee.getCompany }}</h3>

--- a/web/themes/dcamp_2018_theme/styles/main.css
+++ b/web/themes/dcamp_2018_theme/styles/main.css
@@ -2654,6 +2654,20 @@ footer footer .social a:hover {
   content: '\E800';
 }
 
+#block-mainpagecontent-2 div.attendee__speaker {
+  position: absolute;
+  top: 0;
+  left:-5px;
+  padding: 0.2rem 1rem 0.1rem;
+  height: 24px;
+  color: white;
+  background: #2D4084;
+  font-size: 1.2rem;
+  font-weight: 700;
+  text-transform: uppercase; 
+transform: rotate(-20deg);
+}
+
 .frontpage-wrapper #sponsors h3 {
   clear: both;
   text-align: left;


### PR DESCRIPTION
This pull request implements the following:

## Highlight speakers

I don't have a class for this so I am reusing the sponsor one. The problem is that one overlaps another. See plopesc, who is both a speaker and sponsor:

![image](https://user-images.githubusercontent.com/108130/40353483-e7bdd63a-5db1-11e8-8191-3ea7ec398044.png)

@ferelx, can you help with this?

## Highlight attendees who also bought a sponsor without access ticket

Pablo and Salva got a free ticket by getting his session selected, but since they are awesome, they also bought an individual sponsor without access ticket. This pull request highlights them both as speakers and sponsors although there is a CSS issue described above.

## Remove the filtering of people who bought tickets in batches

Javier Salvador bought a bunch of tickets. We were listing just one of them in this cases:

![image](https://user-images.githubusercontent.com/108130/40353831-c0f46fea-5db2-11e8-936d-d84424c74fb4.png)

This happened because there is a setting in EventBrite that we missconfigured by not allowing people who bought many tickets to set the names of the attendees. We changed this at EventBrite so future attendees could be registered with their details. I rather see duplicates than fewer attendees so I have removed the filtering.